### PR TITLE
`curl` header & params fixes

### DIFF
--- a/source/includes/_async_jobs.md
+++ b/source/includes/_async_jobs.md
@@ -15,9 +15,7 @@ Returns all the Async Jobs created for the authenticated shop. When using OAuth,
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/async-jobs" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -92,9 +90,7 @@ Returns the requested Async Job. When using OAuth, only jobs started by the auth
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/async-jobs/57b5aa3b046abfb053d80b52" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE

--- a/source/includes/_customer_lists.md
+++ b/source/includes/_customer_lists.md
@@ -8,9 +8,7 @@ Get all available customer lists.
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/customer-lists" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -55,7 +53,7 @@ Subscribe an email address and optional user details to a specific customer list
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
   -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
   -X PUT \
   -d '{
     "email": "an@email.com",

--- a/source/includes/_newsletters.md
+++ b/source/includes/_newsletters.md
@@ -9,9 +9,7 @@ Returns all the Newsletters created in a shop.
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/newsletters" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -83,9 +81,7 @@ Returns the selected Newsletter and some stats regarding its sending status.
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -179,9 +175,7 @@ Note that if the Newsletter is currently live and sending, paginating results wi
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails?limit=2" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -280,9 +274,7 @@ Returns a Newsletter's email, along with its text & HTML contents.
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/57b5aa3b046abfb053d80b68" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -356,7 +348,7 @@ Refer to the [Async Jobs](#async-jobs) documentation on how to access the job's 
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/ecipients/async-export" \
   -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
   -X POST
 ```
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -87,9 +87,7 @@ Returns all Webhooks registered for the current shop. If authorized through OAut
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/webhooks" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE
@@ -136,9 +134,7 @@ Each webhook includes the following info:
 ```shell
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
-  -H "X-ApiKey: YOUR_API_KEY" \
-  -H "Accept: application/json" \
-  -X GET
+  -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 > EXAMPLE RESPONSE


### PR DESCRIPTION
`-X GET` is redundant as it's the default for `curl`
`-H "Accept: application/json"` is also redundant (in the endpoints that were removed anyway) because only JSON is returned
`-H "Content-Type: application/json"` is actually required in POST/PUT endpoints, otherwise contents are parsed as `x-www-form-urlencoded` (that is to say, they're ignored).