### PR TITLE
Customer Lists, Newsletter audiences and customer segment endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 _yardoc
 doc/
 .idea/
+
+.ruby-version

--- a/source/includes/_abandoned_carts.md
+++ b/source/includes/_abandoned_carts.md
@@ -62,7 +62,7 @@ The items inside the cart. Object contents:
 |----------------:|---------------------------|--------------------------------|
 |**reference:**   |**string, optional**       |*c_123*                         |
 |**variant:**     |**string, optional**       |*c_123_2*                       |
-|**description:** |**string, required**       |*Conversio Hobby Plan*         |
+|**description:** |**string, required**       |*Conversio Hobby Plan*          |
 |**quantity:**    |**number, optional**       |*1*                             |
 |**amount:**      |**number, required**       |*29.00*                         |
 |                 |A single item's price.     |                                |

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -244,6 +244,9 @@ Below is a table of the recognized scopes. Scopes that are prefixed with `write_
 * `read_newsletter_template`: Provides access to a User's Newsletter Templates. This includes contents and sending stats.
 * `read_newsletter_email`: Provides access to the list of emails associated with a sent Newsletter Template. Includes action timestamps (sentAt, openedAt, etc.) and email address info.
 * `read_async_job`: Provides access to Async Jobs, their statuses and results.
+* `read_segments`/`write_segments`: Access to <a href="#customer-segments">Customer Segments</a>.
+* `read_customers`/`write_customers`: Allows reading customer and subscriber data. Write scope allows unsubscribing emails from lists.
+* `read_customer_list`/`write_customer_list`: Provides access to customer lists.
 
 ## HMAC
 

--- a/source/includes/_customer_lists.md
+++ b/source/includes/_customer_lists.md
@@ -1,5 +1,6 @@
 # Customer Lists
-Services related to managing **Customer Lists** (for newsletters) and subscriptions.
+
+Services related to managing **Customer Lists** (for Newsletters) and subscriptions.
 
 ## Get Customer Lists
 
@@ -9,6 +10,7 @@ Get all available customer lists.
 # EXAMPLE REQUEST
 $ curl "https://app.conversio.com/api/v1/customer-lists" \
   -H "X-ApiKey: YOUR_API_KEY"
+  -H "Accept: application/json"
 ```
 
 > EXAMPLE RESPONSE
@@ -18,6 +20,9 @@ $ curl "https://app.conversio.com/api/v1/customer-lists" \
   {
     "id": "57b5aa3b046abfb053d80b52",
     "title": "Weekly Newsletter Subscribers",
+    "singleOptIn": false,
+    "enabled": true,
+    "subscribable": true,
     "subscribers": 3,
     "pending": 2,
     "unsubscribers": 1
@@ -25,9 +30,22 @@ $ curl "https://app.conversio.com/api/v1/customer-lists" \
   {
     "id": "57b5aa3b046abfb053d80b53",
     "title": "New Products Announcements",
+    "singleOptIn": true,
+    "enabled": true,
+    "subscribable": true,
     "subscribers": 3,
     "pending": 2,
     "unsubscribers": 1
+  },
+  {
+    "id": "marketing",
+    "title": "Accepted Marketing",
+    "singleOptIn": true,
+    "enabled": false,
+    "subscribable": false,
+    "subscribers": 0,
+    "pending": 0,
+    "unsubscribers": 0
   }
 ]
 ```
@@ -36,26 +54,186 @@ $ curl "https://app.conversio.com/api/v1/customer-lists" \
 
 `https://app.conversio.com/api/v1/customer-lists`
 
-<aside class="success">
-  Response 200 (application/json)
-</aside>
+### Arguments
+
+These are provided via query params.
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**all:**          |**boolean**                                                              |
+|                  |Whether to include lists that are not subscribable in the return (eg: Accepts Marketing)|
 
 ### Return
 
 The endpoint returns an array with all the Customer Lists in the account. Object keys are:
 
-|Key|Details|
-|-------:|-----------|
-|**id:**|**string**|
-||The Customer List ID. This is used whenever referencing this Customer List in other endpoints.|
-|**title:**|**string**|
-||The title picked by the user for this List. Used in user-facing interfaces.|
-|**subscribers:**|**integer**|
-||The number of subscribers for this list.|
-|**pending:**|**integer**|
-||The number of pending subscribers for this list. A pending subscriber used an online form to sign up, but has not confirmed the subscription yet.|
-|**unsubscribers:**|**integer**|
-||The number of unsubscribers for this list.|
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**id:**           |**string**                                                               |
+|                  |The Customer List ID. This is used whenever referencing this Customer List in other endpoints.|
+|**title:**        |**string**                                                               |
+|                  |The title picked by the user for this List. Used in user-facing interfaces.|
+|**singleOptIn:**  |**boolean**                                                              |
+|                  |Whether this list is single opt-in. If not, a confirmation email is sent on subscription.|
+|**enabled:**      |**boolean**                                                              |
+|                  |Whether this list is enabled. Always `true` except for the `marketing` list where it may be `false`.|
+|**subscribable:** |**boolean**                                                              |
+|                  |Whether subscribers can be added to this list.                           |
+|**subscribers:**  |**integer**                                                              |
+|                  |The number of subscribers for this list.|
+|**pending:**      |**integer**                                                              |
+|                  |The number of pending subscribers for this list. A pending subscriber used an online form to sign up, but has not confirmed the subscription yet.|
+|**unsubscribers:**|**integer**                                                              |
+|                  |The number of unsubscribers for this list.                               |
+
+<aside class="success">
+  Response 200 (application/json)
+</aside>
+
+## Create List
+
+Creates a new Customer List.
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/customer-lists" \
+  -H "X-ApiKey: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -X POST \
+  -d '{
+       "title":"An Awesome List",
+       "singleOptIn":false
+  }'
+```
+
+> RESPONSE
+
+```json
+{
+  "data": {
+    "id": "57b5aa3b046abfb053d80b52",
+    "title": "An Awesome List",
+    "singleOptIn": false,
+    "enabled": true,
+    "subscribable": true
+  }
+}
+```
+
+### Create a Customer List [POST]
+
+`https://app.conversio.com/api/v1/customer-lists`
+
+_OAuth Scopes_: read_customer_list, write_customer_list
+
+### Arguments
+
+|Key             |Details                                                            |
+|---------------:|-------------------------------------------------------------------|
+|**title:**      |**string**                                                         |
+|                |The title for the new List. Used in user-facing interfaces.        |
+|**singleOptIn:**|**boolean, optional**                                              |
+|                |Whether this list is single opt-in. If not, a confirmation email is sent on subscription.|
+
+### Return
+
+The endpoint returns an object with a `data` key with the created list's data in it:
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**id:**           |**string**                                                               |
+|                  |The Customer List ID. This is used whenever referencing this Customer List in other endpoints.|
+|**title:**        |**string**                                                               |
+|                  |The title picked by the user for this List. Used in user-facing interfaces.|
+|**singleOptIn:**  |**boolean**                                                              |
+|                  |Whether this list is single opt-in. If not, a confirmation email is sent on subscription.|
+|**enabled:**      |**boolean**                                                              |
+|                  |Whether this list is enabled. Always `true` except for the `marketing` list where it may be `false`.|
+|**subscribable:** |**boolean**                                                              |
+|                  |Whether subscribers can be added to this list.                           |
+
+<aside class="success">
+  Response 201 (application/json)
+</aside>
+
+<aside class="warning">
+  Response 400 - Invalid arguments
+</aside>
+
+## Update List
+
+Updates an existing Customer List. Updates are applied partially both on PUT and PATCH requests.
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/customer-lists/57b5aa3b046abfb053d80b52" \
+  -H "X-ApiKey: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -X PATCH \
+  -d '{
+       "singleOptIn":true
+  }'
+```
+
+> RESPONSE
+
+```json
+{
+  "data": {
+    "id": "57b5aa3b046abfb053d80b52",
+    "title": "An Awesome List",
+    "singleOptIn": true,
+    "enabled": true,
+    "subscribable": true
+  }
+}
+```
+
+### Update a Customer List [PATCH|PUT]
+
+`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}`
+
+_OAuth Scopes_: read_customer_list, write_customer_list
+
+### Arguments
+
+|Key             |Details                                                            |
+|---------------:|-------------------------------------------------------------------|
+|**title:**      |**string**                                                         |
+|                |A new title for the List. Used in user-facing interfaces.          |
+|**singleOptIn:**|**boolean, optional**                                              |
+|                |Whether this list is single opt-in.                                |
+
+### Return
+
+The endpoint returns an object with a `data` key with the updated list's data in it:
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**id:**           |**string**                                                               |
+|                  |The Customer List ID. This is used whenever referencing this Customer List in other endpoints.|
+|**title:**        |**string**                                                               |
+|                  |The title for this List. Used in user-facing interfaces.                 |
+|**singleOptIn:**  |**boolean**                                                              |
+|                  |Whether this list is single opt-in. If not, a confirmation email is sent on subscription.|
+|**enabled:**      |**boolean**                                                              |
+|                  |Whether this list is enabled. Always `true` except for the `marketing` list where it may be `false`.|
+|**subscribable:** |**boolean**                                                              |
+|                  |Whether subscribers can be added to this list.                           |
+
+<aside class="success">
+  Response 200 (application/json)
+</aside>
+
+<aside class="warning">
+  Response 400 - Invalid arguments
+</aside>
+
+<aside class="warning">
+  Response 404 - No such list
+</aside>
 
 ## Subscribe to List
 
@@ -107,4 +285,191 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
 
 <aside class="warning">
   Response 400 - Invalid email address
+</aside>
+
+## List Subscribers
+
+Returns a list's accepted subscribers, pending subscribers (haven&rsquo;t opted in yet) and unsubscribers.
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/customer-lists/marketing/subscribers" \
+  -H "X-ApiKey: YOUR_API_KEY"
+  -H "Accept: application/json"
+```
+
+> EXAMPLE RESPONSE
+
+```json
+{
+  "data": [
+    {
+      "id": "57b5aa3b046abfb053d80b52",
+      "email": "test@email.com"
+    }
+  ],
+  "meta": {
+    "pages": 1,
+    "total": 1,
+    "limit": 10,
+    "searchAfter": ["test@email.com"],
+    "nextPage": "https://app.conversio.com/api/v1/customer-lists/5b10ded082d2653410054ac3/subscribers?limit=10&searchAfter=test%40email.com"
+  }
+}
+```
+
+### List all Subscribers to a Customer List [GET]
+
+`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+
+_OAuth Scopes_: read_customers
+
+### Arguments
+
+These are provided via query params.
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**pending:**      |**boolean**                                                              |
+|                  |Changes the return to a list of pending subscribers.                     |
+|**unsubscribers:**|**boolean**                                                              |
+|                  |Changes the return to a list of unsubscribers.                           |
+
+### Return
+
+The endpoint returns an object with a `data` key with the found subscribers, and a `meta` key with pagination info. By default, the returned subscribers are Customer objects with event & stats data.
+
+**However**, when querying for `pending` or `unsubscribers` the returned subscribers include only the `email` key. Pagination is also different. This is for legacy reasons and is likely to change (to match the default return) in the future.
+
+To ensure your app supports all returns and is future-proof, expect only the `email` address in the return, and use `nextPage` for pagination.
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**email:**        |**string**                                                               |
+|                  |The email address for the subscriber. Only common field across all queries.|
+
+<aside class="success">
+  Response 200
+</aside>
+
+## Mass Unsubscribe
+
+Removes one or more list's subscribers. There are two versions of this request: one that removes a list of emails, another that removes a whole segment.
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
+  -H "X-ApiKey: YOUR_API_KEY" \
+  -H "Accept: application/json" \
+  -X DELETE \
+  -G \
+  -d '{
+    "emails": ["an@email.com", "another@email.com"]
+  }'
+```
+
+> EXAMPLE RESPONSE
+
+```json
+{
+  "data": {
+    "unsubscribed": 2,
+    "failed": 0,
+    "failedReasons": []
+  }
+}
+```
+
+### Unsubscribe via Email List [DELETE]
+
+`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+
+_OAuth Scopes_: write_customers
+
+### Arguments
+
+These are provided via query params.
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**emails:**       |**string[]**                                                             |
+|                  |The list of emails to unsubscribe from the Customer List.                |
+
+### Return
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**unsubscribed:** |**number**                                                               |
+|                  |How many emails were successfuly unsubscribed.                           |
+|**failed:**       |**number**                                                               |
+|                  |How many emails failed to unsubscribe.                                   |
+|**failedReasons:**|**string[]**                                                             |
+|                  |A list of errors that explain unsubscribe failures.                      |
+
+<aside class="success">
+  Response 200
+</aside>
+
+<aside class="warning">
+  Response 400 - No emails provided, or is not an array
+</aside>
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
+  -H "X-ApiKey: YOUR_API_KEY" \
+  -H "Accept: application/json" \
+  -X DELETE \
+  -G \
+  -d '{
+    "segment": "{\"criteria\":[{\"criteriaName\":\"receipt.sent\",\"negate\":true,\"filters\":[]}]}"
+  }'
+```
+
+> EXAMPLE RESPONSE
+
+```json
+{
+  "data": {
+    "asyncJobId": "5b10ded082d2653410054ac3"
+  }
+}
+```
+
+### Unsubscribe via Customer Segment [DELETE]
+
+`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+
+_OAuth Scopes_: write_customers
+
+### Arguments
+
+These are provided via query params.
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**segment:**      |**string[]**                                                             |
+|                  |A Customer Segment in JSON format.                                       |
+
+### Return
+
+There are two possible return formats: If the number of subscribers to remove is relatively low, they will be removed synchronously with the request and the return will mirror the <a href="#unsubscribe-via-email-list-delete">Unsubscribe via Email List&rsquo;s</a>. Otherwise, an <a href="#async-jobs">Async Job</a> is started and it&rsquo;s ID returned instead inside the `data` key.
+
+The following format is returned only with status 202:
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**asyncJobId:**   |**string**                                                               |
+|                  |An Async Job&rsquo;s ID.                                                 |
+
+<aside class="success">
+  Response 200 - Subscribers removed synchronously
+</aside>
+
+<aside class="success">
+  Response 202 - An async job was created to complete the mass unsubscribe
+</aside>
+
+<aside class="warning">
+  Response 400 - No segment provided
 </aside>

--- a/source/includes/_customer_segments.md
+++ b/source/includes/_customer_segments.md
@@ -1,6 +1,82 @@
 # Customer Segments
 
-Services related to managing **Customer Segments** and subscriptions.
+Services related to managing **Customer Segments**.
+
+## List Customer Segments
+
+Returns all segments and where they&rsquo;re used.
+
+```shell
+# EXAMPLE REQUEST
+$ curl "https://app.conversio.com/api/v1/segments" \
+  -H "X-ApiKey: YOUR_API_KEY"
+  -H "Accept: application/json"
+```
+
+> EXAMPLE RESPONSE
+
+```json
+{
+  "data": [
+    {
+      "id": "5ae9aeedc60b7e00fe9f133a",
+      "name": "\"At Risk\" Repeat Customers",
+      "editable": false,
+      "uses": []
+    },
+    {
+      "id": "5ae9aeedc60b7e00fe9f1330",
+      "name": "First-time Buyers",
+      "editable": false,
+      "uses": [
+        {
+          "modelName": "ReceiptTemplate",
+          "models": [
+            {
+                "id": "5ae9aeedc60b7e00fe9f1356",
+                "enabled": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### List all Customer Segments [GET]
+
+`https://app.conversio.com/api/v1/segments`
+
+_OAuth Scopes_: read_segments
+
+### Return
+
+The endpoint returns an object with a `data` key that contains all the Customer Segments in the account. Object keys are:
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**id:**           |**string**                                                               |
+|                  |The Customer Segment&rsquo;s ID. This is used whenever referencing this Customer Segment in other endpoints.|
+|**name:**         |**string**                                                               |
+|                  |The segment&rsquo; name.                                                 |
+|**editable:**     |**bool**                                                                 |
+|                  |Whether this is a default segment (`false`) or a custom one (`true`)     |
+|**uses:**         |**object[]**                                                             |
+|                  |Where this segment is currently being used, see below.                   |
+
+#### Uses
+
+|Key               |Details                                                                  |
+|-----------------:|-------------------------------------------------------------------------|
+|**modelName:**    |**string**                                                               |
+|                  |Name of the Model where a segment is used, Possible values: `"AsyncJob"`, `"Campaign"`, `"FollowUpTemplate"`, `"NewsletterTemplate"`, `"ReceiptTemplate"`.|
+|**models:**       |**object[]**                                                             |
+|                  |All the objects of `modelName` type where this segment is used. Format depends on model.|
+
+<aside class="success">
+  Response 200
+</aside>
 
 ## Export Segment Customers
 

--- a/source/includes/_newsletters.md
+++ b/source/includes/_newsletters.md
@@ -19,24 +19,27 @@ $ curl "https://app.conversio.com/api/v1/newsletters?limit=2&page=2" \
 {
   "data": [
     {
+      "id": "57b5aa3b046abfb053d80b59",
+      "title": "4th of July Sales",
+      "liveAt": "2017-07-03:00:00.000Z",
+      "audience": {
+        "lists": ["marketing", "57b5aa3b046abfb053d80b52"],
+        "customerSegmentKind": "id",
+        "customerSegmentId": "57b5aa3b046abfb053d80b57",
+        "customerSegmentInline": { "criteria": [] }
+      },
+      "customerLists": [],
+      "customerSegments": [],
+      "status": "scheduled"
+    },
+    {
       "id": "57b5aa3b046abfb053d80b52",
       "title": "Black Friday Announcement",
       "liveAt": "2016-11-20T00:00:00.000Z",
       "customerLists": ["57b5aa3b046abfb053d80b53"],
-      "customerSegments": [],
+      "customerSegments": ["57b5aa3b046abfb053d80b57"],
       "status": "sent",
       "sentAt": "2016-11-20T00:10:15.000Z"
-    },
-    {
-      "id": "57b5aa3b046abfb053d80b59",
-      "title": "4th of July Sales",
-      "liveAt": "2017-07-03:00:00.000Z",
-      "customerLists": [],
-      "customerSegments": [
-        "57b5aa3b046abfb053d80b57",
-        "57b5aa3b046abfb053d80b56"
-      ],
-      "status": "scheduled"
     }
   ],
   "meta": {
@@ -77,22 +80,39 @@ Then endpoint returns an object with a `data` key that is an Array with `limit` 
 
 Each newsletter object includes the following info:
 
-|Key                  |Details|
-|--------------------:|-----------|
-|**id:**              |**string**|
-|                     |The Newsletter's ID. Use it when calling single-newsletter endpoints.|
-|**title:**           |**string**|
-|                     |The Newsletter's title.|
-|**liveAt:**          |**string, optional**|
-|                     |When the Newsletter is set to go live, if scheduled, or when it was set live, if sent or live. Is an **ISO 8601** encoded date. Is omitted if the Newsletter is a draft.|
-|**customerLists:**   |**array[string]**|
-|                     |An array of IDs of Customer Lists who will receive / have received this Newsletter. May be empty.|
-|**customerSegments:**|**array[string]**|
-|                     |An array of IDs of Customer Segments who will receive / have received this Newsletter. May be empty.|
-|**status**           |**string**|
-|                     |The Newsletter's current status. Must be one of "draft", "scheduled", "live", or "sent".|
-|**sentAt**           |**string, optional**|
-|                     |When the Newsletter was fully sent, if such is the case. Is an **ISO 8601** encoded date.|
+|Key                               |Details                                                  |
+|---------------------------------:|---------------------------------------------------------|
+|**id:**                           |**string**                                               |
+|                                  |The Newsletter's ID. Use it when calling single-newsletter endpoints.|
+|**title:**                        |**string**|
+|                                  |The Newsletter's title.|
+|**audience**                      |**object**|
+|                                  |The Newsletter's audience. Can be comprised of one or more lists, a segment ID or an inline segment. See <a href="#audience">below</a>.|
+|**liveAt:**                       |**string, optional**|
+|                                  |When the Newsletter is set to go live, if scheduled, or when it was set live, if sent or live. Is an **ISO 8601** encoded date. Is omitted if the Newsletter is a draft.|
+|**status**                        |**string**|
+|                                  |The Newsletter's current status. Must be one of "draft", "scheduled", "live", or "sent".|
+|**sentAt**                        |**string, optional**|
+|                                  |When the Newsletter was fully sent, if such is the case. Is an **ISO 8601** encoded date.|
+|**customerLists (deprecated):**   |**string[]**|
+|                                  |An array of IDs of Customer Lists who will receive / have received this Newsletter. May be empty. **Deprecated in favour of `audience`.**|
+|**customerSegments (deprecated):**|**string[]**|
+|                                  |An array of IDs of Customer Segments who will receive / have received this Newsletter. May be empty. **Deprecated in favour of `audience`.**|
+
+#### Audience
+
+The Newsletter's Audience. A Newsletter can be sent to one or more Customer Lists, with an optional segment that limits the Newsletter to a subset subscribers on those lists.
+
+|Key                               |Details                                                  |
+|---------------------------------:|---------------------------------------------------------|
+|**lists:**                        |**string[]**                                             |
+|                                  |List IDs. Can only be empty for "draft" Newsletters.     |
+|**customerSegmentKind:**          |**string, optional**                                     |
+|                                  |One of `"inline"`, `"id"` or `null`.                     |
+|**customerSegmentId:**            |**string, optional**                                     |
+|                                  |A Customer Segment's ID. Ignored unless `customerSegmentKind` is `"id"`.|
+|**customerSegmentInline:**        |**object, optional**                                     |
+|                                  |An inline Customer Segment. Ignored unless `customerSegmentKind` is `"inline"`. See <a href="#customer-segments">Customer Segments</a> for structure.|
 
 ## Newsletter Report
 
@@ -113,7 +133,18 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52" \
     "id": "57b5aa3b046abfb053d80b52",
     "title": "Black Friday Announcement",
     "liveAt": "2016-11-20T00:00:00.000Z",
-    "customerLists": ["57b5aa3b046abfb053d80b53"],
+    "audience": {
+      "lists": ["everyone"],
+      "customerSegmentKind": "inline",
+      "customerSegmentInline": {
+        "criteria": [{
+          "criteriaName": "receipt.sent",
+          "negate": true,
+          "filters": []
+        }]
+      }
+    },
+    "customerLists": [],
     "customerSegments": [],
     "status": "sent",
     "sentAt": "2016-11-20T00:10:15.000Z",
@@ -152,26 +183,28 @@ _OAuth Scopes_: read_newsletter_template, write_newsletter_template
 
 Then endpoint returns an object with a `data` key that the Newsletter object. The included info:
 
-|Key                  |Details|
-|--------------------:|-----------|
-|**id:**              |**string**|
-|                     |The Newsletter's ID. Use it when calling single-newsletter endpoints.|
-|**title:**           |**string**|
-|                     |The Newsletter's title.|
-|**liveAt:**          |**string, optional**|
-|                     |When the Newsletter is set to go live, if scheduled, or when it was set live, if sent or live. Is an **ISO 8601** encoded date. Is omitted if the Newsletter is a draft.|
-|**customerLists:**   |**array[string]**|
-|                     |An array of IDs of Customer Lists who will receive / have received this Newsletter. May be empty.|
-|**customerSegments:**|**array[string]**|
-|                     |An array of IDs of Customer Segments who will receive / have received this Newsletter. May be empty.|
-|**status:**          |**string**|
-|                     |The Newsletter's current status. Must be one of "draft", "scheduled", "live", or "sent".|
-|**sentAt:**          |**string, optional**|
-|                     |When the Newsletter was fully sent, if such is the case. Is an **ISO 8601** encoded date.|
-|**stats:**           |**object**|
-|                     |An object with this Newsletter's stats. Included keys are described below.|
-|**contentModules:**  |**array**|
-|                     |An array of the Content Modules in a Newsletter. These represent the content (copy, images, discounts, etc.) in a Newsletter. More details below.|
+|Key                               |Details                                                  |
+|---------------------------------:|---------------------------------------------------------|
+|**id:**                           |**string**                                               |
+|                                  |The Newsletter's ID. Use it when calling single-newsletter endpoints.|
+|**title:**                        |**string**                                               |
+|                                  |The Newsletter's title.                                  |
+|**audience**                      |**object**|
+|                                  |The Newsletter's audience. Can be comprised of one or more lists, a segment ID or an inline segment. See <a href="#audience">above</a>.|
+|**liveAt:**                       |**string, optional**                                     |
+|                                  |When the Newsletter is set to go live, if scheduled, or when it was set live, if sent or live. Is an **ISO 8601** encoded date. Is omitted if the Newsletter is a draft.|
+|**status:**                       |**string**|
+|                                  |The Newsletter's current status. Must be one of "draft", "scheduled", "live", or "sent".|
+|**sentAt:**                       |**string, optional**|
+|                                  |When the Newsletter was fully sent, if such is the case. Is an **ISO 8601** encoded date.|
+|**stats:**                        |**object**|
+|                                  |An object with this Newsletter's stats. Included keys are described below.|
+|**contentModules:**               |**array**|
+|                                  |An array of the Content Modules in a Newsletter. These represent the content (copy, images, discounts, etc.) in a Newsletter. More details below.|
+|**customerLists (deprecated):**   |**string[]**|
+|                                  |An array of IDs of Customer Lists who will receive / have received this Newsletter. May be empty. **Deprecated in favour of `audience`.**|
+|**customerSegments (deprecated):**|**string[]**|
+|                                  |An array of IDs of Customer Segments who will receive / have received this Newsletter. May be empty. **Deprecated in favour of `audience`.**|
 
 #### Stats
 

--- a/source/includes/_newsletters.md
+++ b/source/includes/_newsletters.md
@@ -101,7 +101,7 @@ Each newsletter object includes the following info:
 
 #### Audience
 
-The Newsletter's Audience. A Newsletter can be sent to one or more Customer Lists, with an optional segment that limits the Newsletter to a subset subscribers on those lists.
+The Newsletter's Audience. A Newsletter can be sent to one or more Customer Lists, with an optional segment that limits the Newsletter to a subset of subscribers on those lists.
 
 |Key                               |Details                                                  |
 |---------------------------------:|---------------------------------------------------------|


### PR DESCRIPTION
Updates to the recent changes on the API. I did not include the customer segment creation endpoint as that would require documenting the whole criteria API, which I don't think is settled on yet, particularly WRT property based segmentation.