### PR TITLE
Replace references to app.conversio.com with new CM address

### DIFF
--- a/source/includes/_abandoned_cart_emails.md
+++ b/source/includes/_abandoned_cart_emails.md
@@ -8,7 +8,7 @@ Returns a list of the Abandoned Cart Campaigns in the User's account.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts/campaigns \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -42,7 +42,7 @@ $ curl "https://app.conversio.com/api/v1/abandoned-carts/campaigns \
 
 ### List all Campaigns [GET]
 
-`https://app.conversio.com/api/v1/abandoned-carts/campaigns`
+`https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns`
 
 _OAuth Scopes_: read_abandoned_cart_campaign, write_abandoned_cart_campaign
 
@@ -75,7 +75,7 @@ Returns an Abandoned Cart Campaign in the User's account.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts/campaigns/57b5aa3b046abfb053d80b52 \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns/57b5aa3b046abfb053d80b52 \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -99,7 +99,7 @@ $ curl "https://app.conversio.com/api/v1/abandoned-carts/campaigns/57b5aa3b046ab
 
 ### Show Single Campaign [GET]
 
-`https://app.conversio.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}`
+`https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}`
 
 _OAuth Scopes_: read_abandoned_cart_campaign, write_abandoned_cart_campaign
 
@@ -130,7 +130,7 @@ Returns an Abandoned Cart Template. This contains the basis for the content of e
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts/templates/57b5aa3b046abfb053d80b52 \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts/templates/57b5aa3b046abfb053d80b52 \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -156,8 +156,8 @@ $ curl "https://app.conversio.com/api/v1/abandoned-carts/templates/57b5aa3b046ab
 
 Two possible endpoints:
 
-1. `https://app.conversio.com/api/v1/abandoned-carts/templates/{TEMPLATE_ID}`
-2. `https://app.conversio.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}/templates/{TEMPLATE_ID}`
+1. `https://commerce.campaignmonitor.com/api/v1/abandoned-carts/templates/{TEMPLATE_ID}`
+2. `https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}/templates/{TEMPLATE_ID}`
 
 _OAuth Scopes_: read_abandoned_cart_template, write_abandoned_cart_template
 
@@ -258,7 +258,7 @@ Returns an Abandoned Cart Email, along with its action timestamps.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts/emails/57b5aa3b046abfb053d80b52 \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts/emails/57b5aa3b046abfb053d80b52 \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -285,9 +285,9 @@ $ curl "https://app.conversio.com/api/v1/abandoned-carts/emails/57b5aa3b046abfb0
 
 Three possible endpoints:
 
-1. `https://app.conversio.com/api/v1/abandoned-carts/emails/{EMAIL_ID}`
-2. `https://app.conversio.com/api/v1/abandoned-carts/templates/{TEMPLATE_ID}/emails/{EMAIL_ID}`
-3. `https://app.conversio.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}/templates/{TEMPLATE_ID}/emails/{EMAIL_ID}`
+1. `https://commerce.campaignmonitor.com/api/v1/abandoned-carts/emails/{EMAIL_ID}`
+2. `https://commerce.campaignmonitor.com/api/v1/abandoned-carts/templates/{TEMPLATE_ID}/emails/{EMAIL_ID}`
+3. `https://commerce.campaignmonitor.com/api/v1/abandoned-carts/campaigns/{CAMPAIGN_ID}/templates/{TEMPLATE_ID}/emails/{EMAIL_ID}`
 
 _OAuth Scopes_: read_abandoned_cart_email, write_abandoned_cart_email
 

--- a/source/includes/_abandoned_carts.md
+++ b/source/includes/_abandoned_carts.md
@@ -6,7 +6,7 @@ Services related to managing **Abandoned Carts**. For the Email Campaigns trigge
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -37,7 +37,7 @@ $ curl "https://app.conversio.com/api/v1/abandoned-carts" \
 
 ### Create or Update a Cart [POST]
 
-`https://app.conversio.com/api/v1/abandoned-carts`
+`https://commerce.campaignmonitor.com/api/v1/abandoned-carts`
 
 ### Arguments
 
@@ -86,15 +86,15 @@ Response 200 (application/json)
 
 ```shell
 # DEFINITION
-DELETE https://app.conversio.com/api/v1/abandoned-carts/1a2b3c4d
+DELETE https://commerce.campaignmonitor.com/api/v1/abandoned-carts/1a2b3c4d
 
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/abandoned-carts/1a2b3c4d" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/abandoned-carts/1a2b3c4d" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -X DELETE
 ```
 
-`https://app.conversio.com/api/v1/abandoned-carts/{TOKEN}`
+`https://commerce.campaignmonitor.com/api/v1/abandoned-carts/{TOKEN}`
 
 ### Arguments
 

--- a/source/includes/_async_jobs.md
+++ b/source/includes/_async_jobs.md
@@ -14,7 +14,7 @@ Returns all the Async Jobs created for the authenticated shop. When using OAuth,
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/async-jobs" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/async-jobs" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -29,7 +29,7 @@ $ curl "https://app.conversio.com/api/v1/async-jobs" \
       "status": "done",
       "startedAt": "2017-01-03T16:32:27.741Z",
       "completedAt": "2017-01-03T16:37:20.417Z",
-      "result": "https://app.conversio.com/async-jobs/57b5aa3b046abfb053d80b52.csv"
+      "result": "https://commerce.campaignmonitor.com/async-jobs/57b5aa3b046abfb053d80b52.csv"
     },
     {
       "id": "57b5aa3b046abfb053d80b54",
@@ -50,7 +50,7 @@ $ curl "https://app.conversio.com/api/v1/async-jobs" \
 
 ### List all Jobs [GET]
 
-`https://app.conversio.com/api/v1/async-jobs`
+`https://commerce.campaignmonitor.com/api/v1/async-jobs`
 
 _OAuth Scopes_: read_async_job
 
@@ -89,7 +89,7 @@ Returns the requested Async Job. When using OAuth, only jobs started by the auth
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/async-jobs/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/async-jobs/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -103,14 +103,14 @@ $ curl "https://app.conversio.com/api/v1/async-jobs/57b5aa3b046abfb053d80b52" \
     "status": "done",
     "startedAt": "2017-01-03T16:32:27.741Z",
     "completedAt": "2017-01-03T16:37:20.417Z",
-    "result": "https://app.conversio.com/async-jobs/57b5aa3b046abfb053d80b52.csv"
+    "result": "https://commerce.campaignmonitor.com/async-jobs/57b5aa3b046abfb053d80b52.csv"
   }
 }
 ```
 
 ### Get an Async Job [GET]
 
-`https://app.conversio.com/api/v1/async-jobs/{ASYNC_JOB_ID}`
+`https://commerce.campaignmonitor.com/api/v1/async-jobs/{ASYNC_JOB_ID}`
 
 _OAuth Scopes_: read_async_job
 

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -14,12 +14,12 @@ Conversio provides three types of Authentication, each with its own use case. Th
 
 ## API Key Authentication
 
-All paths should prefixed with https://app.conversio.com/api/v1 and will need the following HTTP header:
+All paths should prefixed with https://commerce.campaignmonitor.com/api/v1 and will need the following HTTP header:
 
 `X-ApiKey: YOUR_API_KEY`
 
 <aside class="notice">
-Your API Key can be found in the store's [profile page](https://app.conversio.com/profile).
+Your API Key can be found in the store's [profile page](https://commerce.campaignmonitor.com/profile).
 </aside>
 
 ## OAuth
@@ -70,7 +70,7 @@ These three steps are described in detail below.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/oauth/authorize" \
+$ curl "https://commerce.campaignmonitor.com/oauth/authorize" \
   -G \
   -X GET \
   -d client_id=57b5aa3b046abfb053d80b52 \
@@ -81,7 +81,7 @@ $ curl "https://app.conversio.com/oauth/authorize" \
 
 To begin the OAuth flow, the User is redirected to Conversio's authorize endpoint:
 
-`https://app.conversio.com/oauth/authorize`
+`https://commerce.campaignmonitor.com/oauth/authorize`
 
 Including the following parameters in the URL query string:
 
@@ -143,7 +143,7 @@ The `code` can now be used to request an Access Token from Conversio.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/oauth/access-token" \
+$ curl "https://commerce.campaignmonitor.com/oauth/access-token" \
   -H "Authorization: Basic NTdiNWFhM2IwNDZhYmZiMDUzZDgwYjUyOndhdGNodS1sb29raW4tYXQ=" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -X POST \
@@ -228,7 +228,7 @@ We support three HMAC algorithms, `HS256`, `HS384` and `HS512`.
 
 ```shell
 # Example authorized request
-$ curl https://app.conversio.com/api/v1 \
+$ curl https://commerce.campaignmonitor.com/api/v1 \
   -H "Authorization: PoP eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdCI6IjEyMzQ1NiIsInRzIjoxMjM0NTY3OH0.Pocf1CzRha25nwCfoZynProYLcV1UE5SlcRGa3qzZXo
 ```
 
@@ -275,7 +275,7 @@ const popToken = jws.sign({ header, payload, secret: clientSecret });
 
 ```shell
 # Example authorized request
-$ curl https://app.conversio.com/api/v1/partners/ \
+$ curl https://commerce.campaignmonitor.com/api/v1/partners/ \
   -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1N2I1YWEzYjA0NmFiZmIwNTNkODBiNTIifQ.sxd8uG4EkeIXHsIIVELrfGTIZcaTFE9a9YY-8HGHuOQ
 ```
 

--- a/source/includes/_coupons.md
+++ b/source/includes/_coupons.md
@@ -5,10 +5,10 @@ Services related to retreiving coupons using the **Coupons API**
 
 ```shell
 # DEFINITION
-GET https://app.conversio.com/api/v1/coupons
+GET https://commerce.campaignmonitor.com/api/v1/coupons
 
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/coupons" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/coupons" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -45,7 +45,7 @@ $ curl "https://app.conversio.com/api/v1/coupons" \
 }
 ```
 
-`https://app.conversio.com/api/v1/coupons`
+`https://commerce.campaignmonitor.com/api/v1/coupons`
 
 Get a list of all coupons
 
@@ -57,10 +57,10 @@ Response 200 (application/json)
 
 ```shell
 # DEFINITION
-GET https://app.conversio.com/api/v1/coupons/1a2b3c4d
+GET https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d
 
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/coupons/1a2b3c4d" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -77,7 +77,7 @@ $ curl "https://app.conversio.com/api/v1/coupons/1a2b3c4d" \
 }
 ```
 
-`https://app.conversio.com/api/v1/coupons/{COUPON_ID}`
+`https://commerce.campaignmonitor.com/api/v1/coupons/{COUPON_ID}`
 
 A single coupon with all of its details
 
@@ -96,15 +96,15 @@ Response 200 (application/json)
 
 ```shell
 # DEFINITION
-DELETE https://app.conversio.com/api/v1/coupons/1a2b3c4d
+DELETE https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d
 
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/coupons/1a2b3c4d" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -X DELETE
 ```
 
-`https://app.conversio.com/api/v1/coupons/{COUPON_ID}`
+`https://commerce.campaignmonitor.com/api/v1/coupons/{COUPON_ID}`
 
 ### Arguments
 
@@ -121,10 +121,10 @@ Response 204 (application/json)
 
 ```shell
 # DEFINITION
-PUT https://app.conversio.com/api/v1/coupons/1a2b3c4d/use
+PUT https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d/use
 
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/coupons/1a2b3c4d/use" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/coupons/1a2b3c4d/use" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -X PUT
   -d '{
@@ -155,7 +155,7 @@ $ curl "https://app.conversio.com/api/v1/coupons/1a2b3c4d/use" \
 }
 ```
 
-`https://app.conversio.com/api/v1/coupons/{COUPON_ID}/use`
+`https://commerce.campaignmonitor.com/api/v1/coupons/{COUPON_ID}/use`
 
 ### Arguments
 

--- a/source/includes/_customer_lists.md
+++ b/source/includes/_customer_lists.md
@@ -8,7 +8,7 @@ Get all available customer lists.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists" \
   -H "X-ApiKey: YOUR_API_KEY"
   -H "Accept: application/json"
 ```
@@ -52,7 +52,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists" \
 
 ### List all Customer Lists [GET]
 
-`https://app.conversio.com/api/v1/customer-lists`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists`
 
 ### Arguments
 
@@ -96,7 +96,7 @@ Creates a new Customer List.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -123,7 +123,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists" \
 
 ### Create a Customer List [POST]
 
-`https://app.conversio.com/api/v1/customer-lists`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists`
 
 _OAuth Scopes_: read_customer_list, write_customer_list
 
@@ -167,7 +167,7 @@ Updates an existing Customer List. Updates are applied partially both on PUT and
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -193,7 +193,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/57b5aa3b046abfb053d80b52
 
 ### Update a Customer List [PATCH|PUT]
 
-`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists/{LIST_ID}`
 
 _OAuth Scopes_: read_customer_list, write_customer_list
 
@@ -241,7 +241,7 @@ Subscribe an email address and optional user details to a specific customer list
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists/LIST_ID/subscriptions" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -264,7 +264,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
 
 ### Subscribe an Email to a Customer List [PUT]
 
-`https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists/LIST_ID/subscriptions`
 
 `LIST_ID` should be the `id` returned in the [list](#get-customer-lists) response.
 
@@ -315,7 +315,7 @@ Returns a list's accepted subscribers, pending subscribers (haven&rsquo;t opted 
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists/marketing/subscribers" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists/marketing/subscribers" \
   -H "X-ApiKey: YOUR_API_KEY"
   -H "Accept: application/json"
 ```
@@ -335,14 +335,14 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/marketing/subscribers" \
     "total": 1,
     "limit": 10,
     "searchAfter": ["test@email.com"],
-    "nextPage": "https://app.conversio.com/api/v1/customer-lists/5b10ded082d2653410054ac3/subscribers?limit=10&searchAfter=test%40email.com"
+    "nextPage": "https://commerce.campaignmonitor.com/api/v1/customer-lists/5b10ded082d2653410054ac3/subscribers?limit=10&searchAfter=test%40email.com"
   }
 }
 ```
 
 ### List all Subscribers to a Customer List [GET]
 
-`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists/{LIST_ID}/subscribers`
 
 _OAuth Scopes_: read_customers
 
@@ -380,7 +380,7 @@ Removes one or more list's subscribers. There are two versions of this request: 
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists/LIST_ID/subscriptions" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json" \
   -X DELETE \
@@ -404,7 +404,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
 
 ### Unsubscribe via Email List [DELETE]
 
-`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists/{LIST_ID}/subscribers`
 
 _OAuth Scopes_: write_customers
 
@@ -438,7 +438,7 @@ These are provided via query params.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/customer-lists/LIST_ID/subscriptions" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json" \
   -X DELETE \
@@ -460,7 +460,7 @@ $ curl "https://app.conversio.com/api/v1/customer-lists/LIST_ID/subscriptions" \
 
 ### Unsubscribe via Customer Segment [DELETE]
 
-`https://app.conversio.com/api/v1/customer-lists/{LIST_ID}/subscribers`
+`https://commerce.campaignmonitor.com/api/v1/customer-lists/{LIST_ID}/subscribers`
 
 _OAuth Scopes_: write_customers
 

--- a/source/includes/_customer_segments.md
+++ b/source/includes/_customer_segments.md
@@ -8,7 +8,7 @@ Returns all segments and where they&rsquo;re used.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/segments" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/segments" \
   -H "X-ApiKey: YOUR_API_KEY"
   -H "Accept: application/json"
 ```
@@ -46,7 +46,7 @@ $ curl "https://app.conversio.com/api/v1/segments" \
 
 ### List all Customer Segments [GET]
 
-`https://app.conversio.com/api/v1/segments`
+`https://commerce.campaignmonitor.com/api/v1/segments`
 
 _OAuth Scopes_: read_segments
 
@@ -86,7 +86,7 @@ Refer to the [Async Jobs](#async-jobs) documentation on how to access the job's 
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/segments/57b5aa3b046abfb053d80b52/async-export" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/segments/57b5aa3b046abfb053d80b52/async-export" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -107,7 +107,7 @@ $ curl "https://app.conversio.com/api/v1/segments/57b5aa3b046abfb053d80b52/async
 
 ### Create Export Job [POST]
 
-`https://app.conversio.com/api/v1/segments/{SEGMENT_ID}/async-export`
+`https://commerce.campaignmonitor.com/api/v1/segments/{SEGMENT_ID}/async-export`
 
 _OAuth Scopes_: read_customers, read_segments
 

--- a/source/includes/_newsletters.md
+++ b/source/includes/_newsletters.md
@@ -8,7 +8,7 @@ Returns all the Newsletters created in a shop.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters?limit=2&page=2" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters?limit=2&page=2" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -47,15 +47,15 @@ $ curl "https://app.conversio.com/api/v1/newsletters?limit=2&page=2" \
     "pages": 3,
     "total": 5,
     "limit": 2,
-    "prevPage": "https://app.conversio.com/api/v1/newsletters?page=1&limit=2",
-    "nextPage": "https://app.conversio.com/api/v1/newsletters?page=3&limit=2"
+    "prevPage": "https://commerce.campaignmonitor.com/api/v1/newsletters?page=1&limit=2",
+    "nextPage": "https://commerce.campaignmonitor.com/api/v1/newsletters?page=3&limit=2"
   }
 }
 ```
 
 ### List all Newsletters [GET]
 
-`https://app.conversio.com/api/v1/newsletters`
+`https://commerce.campaignmonitor.com/api/v1/newsletters`
 
 _OAuth Scopes_: read_newsletter_template, write_newsletter_template
 
@@ -120,7 +120,7 @@ Returns the selected Newsletter and some stats regarding its sending status.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -162,7 +162,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52" \
 
 ### Single Newsletter Report [GET]
 
-`https://app.conversio.com/api/v1/newsletters/{NEWSLETTER_ID}`
+`https://commerce.campaignmonitor.com/api/v1/newsletters/{NEWSLETTER_ID}`
 
 _OAuth Scopes_: read_newsletter_template, write_newsletter_template
 
@@ -278,7 +278,7 @@ Note that if the Newsletter is currently live and sending, paginating results wi
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails?limit=2" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails?limit=2" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -304,7 +304,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/em
     }
   ],
   "meta": {
-    "nextPage": "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/?from=another%40email.com&limit=2",
+    "nextPage": "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/?from=another%40email.com&limit=2",
     "total": 500,
     "limit": 2,
     "pages": 250
@@ -314,7 +314,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/em
 
 ### Newsletter Email List [GET]
 
-`https://app.conversio.com/api/v1/newsletters/{NEWSLETTER_ID}/emails`
+`https://commerce.campaignmonitor.com/api/v1/newsletters/{NEWSLETTER_ID}/emails`
 
 _OAuth Scopes_: read_newsletter_email, write_newsletter_email
 
@@ -378,7 +378,7 @@ Returns a Newsletter's email, along with its text & HTML contents.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/57b5aa3b046abfb053d80b68" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/57b5aa3b046abfb053d80b68" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -405,7 +405,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/em
 
 ### Show Newsletter Email [GET]
 
-`https://app.conversio.com/api/v1/newsletters/{NEWSLETTER_ID}/emails/{EMAIL_ID}`
+`https://commerce.campaignmonitor.com/api/v1/newsletters/{NEWSLETTER_ID}/emails/{EMAIL_ID}`
 
 _OAuth Scopes_: read_newsletter_email, write_newsletter_email
 
@@ -452,7 +452,7 @@ Refer to the [Async Jobs](#async-jobs) documentation on how to access the job's 
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/recipients/async-export" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/recipients/async-export" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -473,7 +473,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/re
 
 ### Create Export Job [POST]
 
-`https://app.conversio.com/api/v1/newsletters/{NEWSLETTER_ID}/recipients/async-export`
+`https://commerce.campaignmonitor.com/api/v1/newsletters/{NEWSLETTER_ID}/recipients/async-export`
 
 _OAuth Scopes_: read_newsletter_email, write_newsletter_email
 
@@ -511,7 +511,7 @@ Refer to the [Async Jobs](#async-jobs) documentation on how to access the job's 
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/async-export" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/emails/async-export" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
@@ -532,7 +532,7 @@ $ curl "https://app.conversio.com/api/v1/newsletters/57b5aa3b046abfb053d80b52/em
 
 ### Create Export Job [POST]
 
-`https://app.conversio.com/api/v1/newsletters/{NEWSLETTER_ID}/emails/async-export`
+`https://commerce.campaignmonitor.com/api/v1/newsletters/{NEWSLETTER_ID}/emails/async-export`
 
 _OAuth Scopes_: read_newsletter_email, write_newsletter_email
 

--- a/source/includes/_partner_apps.md
+++ b/source/includes/_partner_apps.md
@@ -8,7 +8,7 @@ Returns the saved info for the authenticated Partner App.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl https://app.conversio.com/api/v1/partners/ \
+$ curl https://commerce.campaignmonitor.com/api/v1/partners/ \
   -H "Accept: application/json" \
   -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1N2I1YWEzYjA0NmFiZmIwNTNkODBiNTIifQ.sxd8uG4EkeIXHsIIVELrfGTIZcaTFE9a9YY-8HGHuOQ
 ```
@@ -59,7 +59,7 @@ Updates the saved info for the authenticated Partner App. Use this to update a l
 
 ```shell
 # EXAMPLE REQUEST
-$ curl https://app.conversio.com/api/v1/partners/ \
+$ curl https://commerce.campaignmonitor.com/api/v1/partners/ \
   -H "Accept: application/json" \
   -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1N2I1YWEzYjA0NmFiZmIwNTNkODBiNTIifQ.sxd8uG4EkeIXHsIIVELrfGTIZcaTFE9a9YY-8HGHuOQ" \
   -X PATCH \

--- a/source/includes/_product_reviews.md
+++ b/source/includes/_product_reviews.md
@@ -8,7 +8,7 @@ Returns reviews from the most recently created.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/product-reviews?limit=2&page=2" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/product-reviews?limit=2&page=2" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Accept: application/json"
 ```
@@ -48,15 +48,15 @@ $ curl "https://app.conversio.com/api/v1/product-reviews?limit=2&page=2" \
     "pages": 3,
     "total": 5,
     "limit": 2,
-    "prevPage": "https://app.conversio.com/api/v1/product-reviews?page=1&limit=2",
-    "nextPage": "https://app.conversio.com/api/v1/product-reviews?page=3&limit=2"
+    "prevPage": "https://commerce.campaignmonitor.com/api/v1/product-reviews?page=1&limit=2",
+    "nextPage": "https://commerce.campaignmonitor.com/api/v1/product-reviews?page=3&limit=2"
   }
 }
 ```
 
 ### List all Product Reviews [GET]
 
-`https://app.conversio.com/api/v1/product-reviews`
+`https://commerce.campaignmonitor.com/api/v1/product-reviews`
 
 _OAuth Scopes_: read_product_reviews, write_product_reviews
 

--- a/source/includes/_products.md
+++ b/source/includes/_products.md
@@ -6,7 +6,7 @@ These endpoints must be used to send updates about products for our reccommendat
 
 ```shell
 # EXAMPLE REQUEST (SINGLE PRODUCT)
-$ curl "https://app.conversio.com/api/v1/products" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/products" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X POST \
@@ -40,7 +40,7 @@ $ curl "https://app.conversio.com/api/v1/products" \
 
 ```shell
 # EXAMPLE REQUEST (MULTIPLE PRODUCTS)
-$ curl "https://app.conversio.com/api/v1/products" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/products" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X POST \
@@ -98,7 +98,7 @@ $ curl "https://app.conversio.com/api/v1/products" \
 
 ### Create one or more new products [POST]
 
-`POST https://app.conversio.com/api/v1/products`
+`POST https://commerce.campaignmonitor.com/api/v1/products`
 
 ### Arguments
 
@@ -186,7 +186,7 @@ Valid products are accepted and processed and should *not* be re-uploaded.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/products/{product_id}" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/products/{product_id}" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X PUT \
@@ -220,7 +220,7 @@ $ curl "https://app.conversio.com/api/v1/products/{product_id}" \
 
 ### Update a product [PUT]
 
-`PUT https://app.conversio.com/api/v1/products/{product_id}`
+`PUT https://commerce.campaignmonitor.com/api/v1/products/{product_id}`
 
 ### Arguments
 
@@ -243,13 +243,13 @@ Response 200 (application/json)
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/products/{product_id}" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/products/{product_id}" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X DELETE'
 ```
 
-`DELETE https://app.conversio.com/api/v1/products/{product_id}`
+`DELETE https://commerce.campaignmonitor.com/api/v1/products/{product_id}`
 
 <aside class="success">
 Response 204 (application/json)

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -5,7 +5,7 @@ Services related to users using the **Users API**.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/users/current" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/users/current" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -23,7 +23,7 @@ $ curl "https://app.conversio.com/api/v1/users/current" \
 
 ### Retrieve user information [GET]
 
-`https://app.conversio.com/api/v1/users/current`
+`https://commerce.campaignmonitor.com/api/v1/users/current`
 
 The current API user.
 
@@ -35,14 +35,14 @@ Response 200 (application/json)
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/users/uninstall" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/users/uninstall" \
   -X POST \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
 ### Uninstall the user/app [POST]
 
-`https://app.conversio.com/api/v1/users/uninstall`
+`https://commerce.campaignmonitor.com/api/v1/users/uninstall`
 
 Tells Conversio to uninstall the user associated with the given API key. Among
 other things, this automatically unsubscribes the user from a premium plan.

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -307,7 +307,7 @@ Returns all Webhooks registered for the current shop. If authorized through OAut
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/webhooks" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/webhooks" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -327,7 +327,7 @@ $ curl "https://app.conversio.com/api/v1/webhooks" \
 
 ### List all Webhooks [GET]
 
-`https://app.conversio.com/api/v1/webhooks`
+`https://commerce.campaignmonitor.com/api/v1/webhooks`
 
 _OAuth Scopes_: read_webhook, write_webhook
 
@@ -354,7 +354,7 @@ Each webhook includes the following info:
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY"
 ```
 
@@ -372,7 +372,7 @@ $ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
 
 ### Show Single Webhook [GET]
 
-`https://app.conversio.com/api/v1/webhooks/{WEBHOOK_ID}`
+`https://commerce.campaignmonitor.com/api/v1/webhooks/{WEBHOOK_ID}`
 
 _OAuth Scopes_: read_webhook, write_webhook
 
@@ -413,7 +413,7 @@ Only one Webhook for a unique topic & endpoint combination can exist for each Sh
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/webhooks" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/webhooks" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X POST \
@@ -447,7 +447,7 @@ $ curl "https://app.conversio.com/api/v1/webhooks" \
 
 ### Create Webhook [POST]
 
-`https://app.conversio.com/api/v1/webhooks`
+`https://commerce.campaignmonitor.com/api/v1/webhooks`
 
 _OAuth Scopes_: write_webhook
 
@@ -495,7 +495,7 @@ Update an existing webhook with new data. Can change either the topic or endpoin
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X PATCH \
@@ -528,7 +528,7 @@ $ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
 
 ### Update Webhook [PATCH/PUT]
 
-`https://app.conversio.com/api/v1/webhooks/{WEBHOOK_ID}`
+`https://commerce.campaignmonitor.com/api/v1/webhooks/{WEBHOOK_ID}`
 
 _OAuth Scopes_: write_webhook
 
@@ -592,7 +592,7 @@ Delete an existing Webhook to stop receiving data at the endpoint.
 
 ```shell
 # EXAMPLE REQUEST
-$ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
+$ curl "https://commerce.campaignmonitor.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
   -H "X-ApiKey: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -X DELETE
@@ -600,7 +600,7 @@ $ curl "https://app.conversio.com/api/v1/webhooks/57b5aa3b046abfb053d80b52" \
 
 ### Delete Webhook [DELETE]
 
-`https://app.conversio.com/api/v1/webhooks/{WEBHOOK_ID}`
+`https://commerce.campaignmonitor.com/api/v1/webhooks/{WEBHOOK_ID}`
 
 _OAuth Scopes_: write_webhook
 

--- a/source/index.md
+++ b/source/index.md
@@ -5,7 +5,7 @@ language_tabs:
   - shell
 
 toc_footers:
-  - <a href='https://app.conversio.com'>Sign Up for an API Key</a>
+  - <a href='https://commerce.campaignmonitor.com'>Sign Up for an API Key</a>
   - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
 
 includes:


### PR DESCRIPTION
Removes all traces of app.conversio.com and replaces them with the updated CM domain `commerce.campaignmonitor.com`.